### PR TITLE
WVP-339 - Update package graphql to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@graphql-tools/load": "7.7.1",
         "@graphql-tools/schema": "8.5.1",
         "amqplib": "^0.10.3",
-        "graphql": "16.7.1",
+        "graphql": "^16.8.1",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.0.1",
         "pino": "^8.15.1",
@@ -5247,9 +5247,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-      "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@graphql-tools/load": "7.7.1",
     "@graphql-tools/schema": "8.5.1",
     "amqplib": "^0.10.3",
-    "graphql": "16.7.1",
+    "graphql": "^16.8.1",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.0.1",
     "pino": "^8.15.1",


### PR DESCRIPTION
This update is to make all new services work, since they use a different version of the npm module `graphql` if someone want to use the older version, just make sure to use the tag `0.0.5` 